### PR TITLE
Update mappings to be compatible with AstroNvim v3

### DIFF
--- a/mappings.lua
+++ b/mappings.lua
@@ -8,10 +8,13 @@ return {
   n = {
     -- second key is the lefthand side of the map
     -- mappings seen under group name "Buffer"
-    ["<leader>bb"] = { "<cmd>tabnew<cr>", desc = "New tab" },
-    ["<leader>bc"] = { "<cmd>BufferLinePickClose<cr>", desc = "Pick to close" },
-    ["<leader>bj"] = { "<cmd>BufferLinePick<cr>", desc = "Pick to jump" },
-    ["<leader>bt"] = { "<cmd>BufferLineSortByTabs<cr>", desc = "Sort by tabs" },
+    ["<leader>bn"] = { "<cmd>tabnew<cr>", desc = "New tab" },
+    ["<leader>bD"] = {
+      function()
+        require("astronvim.utils.status").heirline.buffer_picker(function(bufnr) require("astronvim.utils.buffer").close(bufnr) end)
+      end,
+      desc = "Pick to close",
+    },
     -- tables with the `name` key will be registered with which-key if it's installed
     -- this is useful for naming menus
     ["<leader>b"] = { name = "Buffers" },


### PR DESCRIPTION
Since v3.0 of AstroNvim the plugin 'bufferline.nvim' isn't used anymore. 

- New tab: `<leader>bb` is already used in v3 ("Select buffer from tabline"). Change to `<leader>bn`
- Pick to close: `<leader>bc` is already used in v3 ("Close all buffers except current"). Change to `<leader>bD` 
- Pick to jump: already coverd in v3 with `<leader>bb` 
- Sort by tabs: Not necessary anymore (?) because v3 scopes buffers according to tabs